### PR TITLE
fix US-RSE blog formatting

### DIFF
--- a/content/blog/2019-09-10-growth-of-the-us-rse-association.md
+++ b/content/blog/2019-09-10-growth-of-the-us-rse-association.md
@@ -4,59 +4,106 @@ date: 2019-09-10
 author: "Ian Cosden and Sandra Gesing"
 ---
 
-Research Software Engineers are playing an increasingly critical role in research software development 
-(as described in a [previous blog post](http://urssi.us/blog/2019/04/16/why-research-software-engineers/)). A community of 
-RSEs began to form in the UK in 2012, by Jan 2019, the European Commission had published a report [Recognising the Importance of 
-Software in Research - Research Software Engineers (RSEs), a UK 
-Example](https://ec.europa.eu/info/sites/info/files/research_and_innovation/importance_of_software_in_research.pdf) 
-emphasizing that RSEs are crucial to sustain research software and research computing.  
-In the US, the people in these roles have begun to build a more formal community with the 
-[US Research Software Engineer Association (US-RSE)](https://us-rse.org/).  
-The first half of 2019 brought a rapid growth in both community involvement and activities 
-surrounding the US-RSE Association, and the second half looks to promise more of the same. 
+Research Software Engineers are playing an increasingly critical role
+in research software development (as described in a [previous blog
+post](http://urssi.us/blog/2019/04/16/why-research-software-engineers/)). A
+community of RSEs began to form in the UK in 2012, by Jan 2019, the
+European Commission had published a report [Recognising the Importance
+of Software in Research - Research Software Engineers (RSEs), a UK
+Example](https://ec.europa.eu/info/sites/info/files/research_and_innovation/importance_of_software_in_research.pdf)
+emphasizing that RSEs are crucial to sustain research software and
+research computing.  In the US, the people in these roles have begun
+to build a more formal community with the [US Research Software
+Engineer Association (US-RSE)](https://us-rse.org/).  The first half
+of 2019 brought a rapid growth in both community involvement and
+activities surrounding the US-RSE Association, and the second half
+looks to promise more of the same.
 
 **US-RSE History**
 
-The US-RSE Association can trace its roots back to two activities in the winter of 2017-2018.  
-The first was an [international survey of RSEs](https://www.software.ac.uk/what-do-we-know-about-rses-results-our-international-surveys).
-There was a final question on that survey “Would you be interested in helping to form a community of RSEs in the US?”  
-Out of nearly 200 respondents, about a dozen people answered yes and started talking.  Shortly after that, the UK RSE Association 
-sponsored an [international RSE leaders workshop](https://rse.ac.uk/rse-international-leaders-meeting/) - 
-a meeting designed to bring together RSE team leads from across the world to connect and share experiences.  
-Five US representatives (including the two of us) traveled to London to participate in the workshop and left energized and 
-committed to developing an RSE community in the US.  That was February 2018 and over the course of the following year, progress was 
-slow.  The last few months (April - August 2019), on the other hand, has seen significant growth in both membership and 
-activity (see the plot below).  We have updated and expanded a [website](https://us-rse.org), 
-formed a [steering committee](https://us-rse.org/steering-committee/), created a logo, and formed working groups to work on 
-everything from social media to an official code of conduct.  We now have an active slack channel and a twitter account, 
-[@us_rse](https://twitter.com/us_rse). And we recently ran an event at PEARC19, and have a couple of upcoming events at SC19 (see below).
+The US-RSE Association can trace its roots back to two activities in
+the winter of 2017-2018.  The first was an [international survey of
+RSEs](https://www.software.ac.uk/what-do-we-know-about-rses-results-our-international-surveys).
+There was a final question on that survey “Would you be interested in
+helping to form a community of RSEs in the US?”  Out of nearly 200
+respondents, about a dozen people answered yes and started talking.
+Shortly after that, the UK RSE Association sponsored an [international
+RSE leaders
+workshop](https://rse.ac.uk/rse-international-leaders-meeting/) - a
+meeting designed to bring together RSE team leads from across the
+world to connect and share experiences.  Five US representatives
+(including the two of us) traveled to London to participate in the
+workshop and left energized and committed to developing an RSE
+community in the US.  That was February 2018 and over the course of
+the following year, progress was slow.  The last few months (April -
+August 2019), on the other hand, has seen significant growth in both
+membership and activity (see the plot below).  We have updated and
+expanded a [website](https://us-rse.org), formed a [steering
+committee](https://us-rse.org/steering-committee/), created a logo,
+and formed working groups to work on everything from social media to
+an official code of conduct.  We now have an active slack channel and
+a twitter account, [@us_rse](https://twitter.com/us_rse). And we
+recently ran an event at PEARC19, and have a couple of upcoming events
+at SC19 (see below).
 
-<img src="https://raw.githubusercontent.com/si2-urssi/website/master/static/img/US-RSE-Membership-August2019.png" alt="drawing" width="800"/>
+<img
+src="https://raw.githubusercontent.com/si2-urssi/website/master/static/img/US-RSE-Membership-August2019.png"
+alt="drawing" width="800"/>
 
 **Goals of the US-RSE**
 
-The US-RSE Association has defined Research Software Engineers (RSEs) with the following statement: 
-*We like an inclusive definition of Research Software Engineers to encompass those who regularly use expertise in programming to 
-advance research. This includes researchers who spend a significant amount of time programming, full-time software engineers 
-writing code to solve research problems, and those somewhere in-between. We aspire to apply the skills and practices of 
-software development to research to create more robust, manageable, and sustainable research software.*
+The US-RSE Association has defined Research Software Engineers (RSEs)
+with the following statement: 
+
+*We like an inclusive definition of Research Software Engineers to
+encompass those who regularly use expertise in programming to advance
+research. This includes researchers who spend a significant amount of
+time programming, full-time software engineers writing code to solve
+research problems, and those somewhere in-between. We aspire to apply
+the skills and practices of software development to research to create
+more robust, manageable, and sustainable research software.*
 
 And the US-RSE Association has set the following three goals:
-1. Community - We seek to provide a coherent association of those who identify with the role (not necessarily title) of Research Software Engineer based on our inclusive definition. This group aims to provide  members of the community the ability to share knowledge, professional connections, and resources.
-2. Advocacy - We aim to promote RSEs impact on research, highlighting the increasingly critical and valuable role RSEs serve.
-3. Resources - We strive to provide useful resources to multiple demographics. For current and future RSEs we strive to provide technical and career development resources to support their professional development. We aim to provide access to information and material to support the establishment and expansion of RSE positions and groups within the research ecosystem including the material for making business justifications for RSEs.
+
+1. Community - We seek to provide a coherent association of those who
+identify with the role (not necessarily title) of Research Software
+Engineer based on our inclusive definition. This group aims to provide
+members of the community the ability to share knowledge, professional
+connections, and resources.
+
+2. Advocacy - We aim to promote RSEs impact on research, highlighting
+the increasingly critical and valuable role RSEs serve.
+
+3. Resources - We strive to provide useful resources to multiple
+demographics. For current and future RSEs we strive to provide
+technical and career development resources to support their
+professional development. We aim to provide access to information and
+material to support the establishment and expansion of RSE positions
+and groups within the research ecosystem including the material for
+making business justifications for RSEs.
 
 **Upcoming US-RSE Events**
 
-The members of the US-RSE Association will be organizing and attending the following panels in an effort to spread the word and 
-discuss the needs of the community.  
+The members of the US-RSE Association will be organizing and attending
+the following panels in an effort to spread the word and discuss the
+needs of the community.
 
 **SC19**
-1. [Developing and Managing Research Software in Universities and National Labs](https://sc19.supercomputing.org/presentation/?id=pan108&sess=sess226)
-2. [Sustainability of HPC Research Computing - The Importance of Collaborations for Fostering Career Paths for Facilitators, Research Software Engineers, and Gateway Creators](https://sc19.supercomputing.org/presentation/?id=pan109&sess=sess227)
 
-**Want to get involved?**
-Do you identify as an RSE?  Are you interested in becoming one? Are you looking for an RSE position?  Are you passionate about developing research software?  
-Want to get involved or just watch from a distance?  If you answered yes to any of these, participating in the US-RSE Association 
-is easy.  It simply requires filling out a form to get an invitation to join the US-RSE slack workspace and US-RSE mailing list: 
-[https://us-rse.org/join/](https://us-rse.org/join/). 
+1. [Developing and Managing Research Software in Universities and National Labs](https://sc19.supercomputing.org/presentation/?id=pan108&sess=sess226) 
+
+2. [Sustainability of HPC Research Computing - The Importance of
+Collaborations for Fostering Career Paths for Facilitators, Research
+Software Engineers, and Gateway
+Creators](https://sc19.supercomputing.org/presentation/?id=pan109&sess=sess227)
+
+**Want to get involved?** 
+
+Do you identify as an RSE?  Are you
+interested in becoming one? Are you looking for an RSE position?  Are
+you passionate about developing research software?  Want to get
+involved or just watch from a distance?  If you answered yes to any of
+these, participating in the US-RSE Association is easy.  It simply
+requires filling out a form to get an invitation to join the US-RSE
+slack workspace and US-RSE mailing list:
+[https://us-rse.org/join/](https://us-rse.org/join/).


### PR DESCRIPTION
This PR just cleans up the formatting in the recent US-RSE blog post @sandragesing and I wrote (http://urssi.us/blog/2019/09/10/growth-of-the-us-rse-association/).  

The only changes I made were formatting.  Mostly just markdown paragraph breaks.  The current version has the numbered lists all in a single paragraph making it harder to read.  

This change (rendered locally on my machine) looks like this:

![image](https://user-images.githubusercontent.com/5824618/64723469-9b7b9680-d49e-11e9-8554-3e7cc9fa461b.png)
