### PR TITLE
Removes extraneous comma in mission statement on front page

### DIFF
--- a/themes/urssi/layouts/index.html
+++ b/themes/urssi/layouts/index.html
@@ -45,7 +45,7 @@
     <b>
         use
     </b>
-    , of software for a more sustainable research enterprise.
+    of software for a more sustainable research enterprise.
 </p>
 						<a href="{{.Site.BaseURL}}about" class="btn btn-action-1">
 									Learn more about our mission and vision


### PR DESCRIPTION
Currently, the mission statement on the landing page is:
> URSSI's mission is to improve the recognition , development, and use , of software for a more sustainable research enterprise.

This fixes it to
> URSSI's mission is to improve the recognition , development, and use of software for a more sustainable research enterprise.