### PR TITLE
FIX: Update site to use modern Hugo and restore local builds

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,8 +9,8 @@ disqusShortname = ""
 ignoreFiles = ["\\.Rmd$", "_files$", "_cache$"]
 footnotereturnlinkcontents = "↩"
 
-paginate = 4
-paginatePath = "page"
+pagination.pagerSize = 4
+pagination.path = "page"
 rssLimit = 20
 
 [permalinks]

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo -F"
 
 [context.production.environment]
-  HUGO_VERSION = "0.118.2"
+  HUGO_VERSION = "0.147.9"
 
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.118.2"
+  HUGO_VERSION = "0.147.9"

--- a/themes/urssi/layouts/blog/list.html
+++ b/themes/urssi/layouts/blog/list.html
@@ -52,7 +52,7 @@
           <p class="mb-0 mt-xl-12 text-capitalize fs-4 text-dark-2">{{ . }} •</p>
        							 {{ end }}
 							{{ end }} 
-					{{ template "_internal/pagination.html" . }}
+					{{ .Paginator }}
 					</div>
 				</div>
 			</div>

--- a/themes/urssi/layouts/projects/list.html
+++ b/themes/urssi/layouts/projects/list.html
@@ -43,9 +43,6 @@
 						<p class="mb-0 text-dark-1 fs-3">
 									{{ .abstract | truncate 500 | safeHTML }}
 						</p>
-								 
-          <!-- <li><a href="/tags/{{ . | urlize }}" class="tag">{{ . }}</a></li> -->
-          
          
 						{{ end }}  
 					</div>


### PR DESCRIPTION
Resolves https://github.com/si2-urssi/website/issues/54

* Update APIs deprecated in Hugo v0.128.0 and later removed.
   - 'paginate' -> 'pagination.pagerSize'
   - 'paginatePath' -> 'pagination.path'
* Remove comment that was raising error.
* Update Hugo deployment version to v0.147.9.