### PR TITLE
ENH: Add Pixi project workspace

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# SCM syntax highlighting & preventing 3-way merges
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .DS_Store
 public/
+# pixi environments
+.pixi
+*.egg-info

--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 URSSI is a newly launched institute with funding from the Alfred P. Sloan Foundation and the National Science Foundation. The effort began as a planning grant (2018-2022) from [NSF](https://www.nsf.gov/awardsearch/showAward?AWD_ID=1743188).
 
+## Local development setup
+
+1. Install [Pixi](https://pixi.sh/)
+2. Fork this repository on GitHub
+3. Clone your fork locally with the `--recurse-submodules` option
+
+```
+git clone --recurse-submodules <repository URL>
+```
+
+4. Run
+
+```
+pixi run start
+```
+
 ## How to add content
 
 This is a static site based on Hugo. To preview additions and changes on your local machine, you will need to [install Hugo](https://gohugo.io/getting-started/installing/)
@@ -21,13 +37,13 @@ The site will be built automatically once you push commits to GitHub. If you wis
 
 This requires you to have Hugo installed locally. You can learn more about installing Hugo here: https://gohugo.io/getting-started/installing/
 
-To preview draft content: 
+To preview draft content:
 
 ```
 hugo serve -F
 ```
 
-Once you're happy with your post, remove `draft: true` from the yml and send a pull request explaining your additions and/or changes. 
+Once you're happy with your post, remove `draft: true` from the yml and send a pull request explaining your additions and/or changes.
 
 
 ## Sending a pull request

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,0 +1,116 @@
+version: 6
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hugo-0.147.9-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.1.0-h767d61c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_3.conda
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hugo-0.147.9-h286801f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-20.1.7-ha82da77_0.conda
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hugo-0.147.9-ha2862d8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  md5: d7c89558ba9fa0495403155b64376d81
+  license: None
+  size: 2562
+  timestamp: 1578324546067
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  build_number: 16
+  sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+  md5: 73aaf86a425cc6e73fcf236a5a46396d
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23621
+  timestamp: 1650670423406
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hugo-0.147.9-h5888daf_0.conda
+  sha256: ca994e27f9e4f9c9b6925f5f0fc454d5e81d0731dd7653bf3efb27ab08257774
+  md5: e996172a635029a88ef39b37a298587c
+  depends:
+  - __glibc >=2.17
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  size: 17681489
+  timestamp: 1750731883277
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/hugo-0.147.9-h286801f_0.conda
+  sha256: f1b0aece4d757ae3ed04a3ef71f071f90cb029b18eaeb25d5a8997da92c1a66e
+  md5: a13adcb37e2eeeb1a08a18d237021d04
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  license: Apache-2.0
+  license_family: APACHE
+  size: 15749556
+  timestamp: 1750732201516
+- conda: https://conda.anaconda.org/conda-forge/win-64/hugo-0.147.9-ha2862d8_0.conda
+  sha256: 723f020ab14f7b78354dc25e308573896978b351e6c35517112ef5b0df6a8780
+  md5: b661413a4d69dbacfc774dfae63e320d
+  depends:
+  - ucrt >=10.0.20348.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 17231139
+  timestamp: 1750732388722
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-20.1.7-ha82da77_0.conda
+  sha256: a3fd34773f1252a4f089e74a075ff5f0f6b878aede097e83a405f35687c36f24
+  md5: 881de227abdddbe596239fa9e82eb3ab
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 567189
+  timestamp: 1749847129529
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.1.0-h767d61c_3.conda
+  sha256: 59a87161212abe8acc57d318b0cc8636eb834cdfdfddcf1f588b5493644b39a3
+  md5: 9e60c55e725c20d23125a5f0dd69af5d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgcc-ng ==15.1.0=*_3
+  - libgomp 15.1.0 h767d61c_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 824921
+  timestamp: 1750808216066
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_3.conda
+  sha256: 43710ab4de0cd7ff8467abff8d11e7bb0e36569df04ce1c099d48601818f11d1
+  md5: 3cd1a7238a0dd3d0860fdefc496cc854
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 447068
+  timestamp: 1750808138400
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_3.conda
+  sha256: 7650837344b7850b62fdba02155da0b159cf472b9ab59eb7b472f7bd01dff241
+  md5: 6d11a5edae89fe413c0569f16d308f5a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 15.1.0 h767d61c_3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  size: 3896407
+  timestamp: 1750808251302
+- conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
+  sha256: db8dead3dd30fb1a032737554ce91e2819b43496a0db09927edf01c32b577450
+  md5: 6797b005cd0f439c4c5c9ac565783700
+  constrains:
+  - vs2015_runtime >=14.29.30037
+  license: LicenseRef-MicrosoftWindowsSDK10
+  size: 559710
+  timestamp: 1728377334097

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,16 @@
+[workspace]
+channels = ["conda-forge"]
+name = "website"
+platforms = ["linux-64", "osx-arm64", "win-64"]
+version = "0.1.0"
+
+[tasks.serve]
+description = "Serve the site with Hugo"
+cmd = "hugo serve --buildFuture"
+
+[tasks.start]
+description = "Get started"
+depends-on = ["serve"]
+
+[dependencies]
+hugo = ">=0.147.9,<0.148"


### PR DESCRIPTION
* Add platform support for linux-64, osx-arm64, win-64.
* Add serve task to build and run the site.
* Add canonical 'start' task to get running immediately.
* Add local development instructions with Pixi.

Requires PR #61 to go in first.